### PR TITLE
Controller map supplier

### DIFF
--- a/src/main/java/io/leonis/zosma/ipc/peripheral/Controller.java
+++ b/src/main/java/io/leonis/zosma/ipc/peripheral/Controller.java
@@ -1,7 +1,7 @@
 package io.leonis.zosma.ipc.peripheral;
 
 import io.leonis.zosma.game.Identity;
-import java.util.Set;
+import java.util.*;
 import lombok.Value;
 
 /**
@@ -38,6 +38,19 @@ public interface Controller extends Identity.Supplier {
      * @return Set of connected controllers.
      */
     Set<C> getControllerSet();
+  }
+
+  /**
+   * The Interface MapSupplier.
+   *
+   * Supplies a {@link Map} of {@link Identity identities} of controllable objects to a {@link Set}
+   * of applicable {@link ControllerIdentity ControllerIdentities}.
+   *
+   * @param <I> identity type of a controllable object.
+   */
+  interface MapSupplier<I extends Identity> {
+
+    Map<I, Set<ControllerIdentity>> getControllerMapping();
   }
 
   /**

--- a/src/main/java/io/leonis/zosma/ipc/peripheral/ControllerPublisher.java
+++ b/src/main/java/io/leonis/zosma/ipc/peripheral/ControllerPublisher.java
@@ -12,22 +12,54 @@ import org.reactivestreams.*;
 import reactor.core.publisher.Flux;
 
 /**
+ * The Class ControllerPublisher.
+ *
+ * Publishes an container with implements {@link Controller.MapSupplier} and
+ * {@link Controller.SetSupplier}. This allows dynamic rebinding of controllers on runtime.
+ *
+ * TODO determine if interval should be configurable in this wrapper class.
  * @author Jeroen de Jong
  */
 @AllArgsConstructor
-public final class ControllerPublisher<I extends Identity, C extends Controller> implements Publisher<Frame<C, I>> {
+public final class ControllerPublisher<I extends Identity, C extends Controller>
+    implements Publisher<Frame<C, I>> {
+
+  /**
+   * Publisher of a set of connected controllers.
+   */
   private final Publisher<Controller.SetSupplier<C>> setSupplierPublisher;
+
+  /**
+   * Publisher of the mapping of controllable to set of controllers.
+   */
   private final Publisher<Controller.MapSupplier<I>> mapSupplierPublisher;
 
+  /**
+   * Creates an ControllerPublisher that allows for dynamic rebinding based on the latest map
+   * published on the provided {@code mapPublisher}.
+   *
+   * @param amount       The amount of controllers to listen for.
+   * @param interval     The poll rate.
+   * @param adapter      The adapter from jamepad to an controller object.
+   * @param mapPublisher Publisher of the assignment map.
+   */
   public ControllerPublisher(
       final int amount,
       final Duration interval,
       final Function<ControllerIndex, C> adapter,
-      final Publisher<Controller.MapSupplier<I>> mapSupplierPublisher
+      final Publisher<Controller.MapSupplier<I>> mapPublisher
   ){
-    this(new ControllerSetPublisher<>(interval, adapter, amount), mapSupplierPublisher);
+    this(new ControllerSetPublisher<>(interval, adapter, amount), mapPublisher);
   }
 
+  /**
+   * Creates an ControllerPublisher with a static mapping.
+   *
+   * @param amount   The amount of controllers to listen for.
+   * @param interval The poll rate.
+   * @param adapter  The adapter from jamepad to an controller object.
+   * @param mapping  The assignment mapping.
+   */
   public ControllerPublisher(
       final int amount,
       final Duration interval,
@@ -40,9 +72,7 @@ public final class ControllerPublisher<I extends Identity, C extends Controller>
 
   @Override
   public void subscribe(final Subscriber<? super Frame<C, I>> s) {
-    Flux.combineLatest(setSupplierPublisher, mapSupplierPublisher, Frame::new)
-        .doOnNext(System.out::println)
-        .subscribe(s);
+    Flux.combineLatest(setSupplierPublisher, mapSupplierPublisher, Frame::new).subscribe(s);
   }
 
   @Value

--- a/src/main/java/io/leonis/zosma/ipc/peripheral/ControllerPublisher.java
+++ b/src/main/java/io/leonis/zosma/ipc/peripheral/ControllerPublisher.java
@@ -2,7 +2,7 @@ package io.leonis.zosma.ipc.peripheral;
 
 import com.studiohartman.jamepad.ControllerIndex;
 import io.leonis.zosma.game.Identity;
-import io.leonis.zosma.ipc.peripheral.Controller.*;
+import io.leonis.zosma.ipc.peripheral.Controller.ControllerIdentity;
 import io.leonis.zosma.ipc.peripheral.ControllerPublisher.Frame;
 import java.time.Duration;
 import java.util.*;
@@ -14,9 +14,8 @@ import reactor.core.publisher.Flux;
 /**
  * @author Jeroen de Jong
  */
-@Value
 @AllArgsConstructor
-public class ControllerPublisher<I extends Identity, C extends Controller> implements Publisher<Frame> {
+public final class ControllerPublisher<I extends Identity, C extends Controller> implements Publisher<Frame<C, I>> {
   private final Publisher<Controller.SetSupplier<C>> setSupplierPublisher;
   private final Publisher<Controller.MapSupplier<I>> mapSupplierPublisher;
 
@@ -40,13 +39,15 @@ public class ControllerPublisher<I extends Identity, C extends Controller> imple
   }
 
   @Override
-  public void subscribe(final Subscriber<? super Frame> s) {
+  public void subscribe(final Subscriber<? super Frame<C, I>> s) {
     Flux.combineLatest(setSupplierPublisher, mapSupplierPublisher, Frame::new)
+        .doOnNext(System.out::println)
         .subscribe(s);
   }
 
   @Value
-  class Frame implements Controller.SetSupplier<C>, Controller.MapSupplier<I> {
+  static class Frame<C extends Controller, I extends Identity>
+      implements Controller.SetSupplier<C>, Controller.MapSupplier<I> {
     @lombok.experimental.Delegate
     Controller.SetSupplier<C> set;
     @lombok.experimental.Delegate

--- a/src/main/java/io/leonis/zosma/ipc/peripheral/ControllerPublisher.java
+++ b/src/main/java/io/leonis/zosma/ipc/peripheral/ControllerPublisher.java
@@ -75,8 +75,8 @@ public final class ControllerPublisher<I extends Identity, C extends Controller>
     Flux.combineLatest(setSupplierPublisher, mapSupplierPublisher, Frame::new).subscribe(s);
   }
 
-  @Value
-  static class Frame<C extends Controller, I extends Identity>
+  @AllArgsConstructor
+  static final class Frame<C extends Controller, I extends Identity>
       implements Controller.SetSupplier<C>, Controller.MapSupplier<I> {
     @lombok.experimental.Delegate
     Controller.SetSupplier<C> set;

--- a/src/main/java/io/leonis/zosma/ipc/peripheral/ControllerSetPublisher.java
+++ b/src/main/java/io/leonis/zosma/ipc/peripheral/ControllerSetPublisher.java
@@ -1,0 +1,87 @@
+package io.leonis.zosma.ipc.peripheral;
+
+import com.studiohartman.jamepad.*;
+import java.time.Duration;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.*;
+import lombok.Value;
+import org.reactivestreams.*;
+import reactor.core.publisher.Flux;
+
+/**
+ * The Class ControllerSetPublisher.
+ *
+ * Publishes all connected controllers at a provided interval.
+ *
+ * @param <C> Identity of {@link Controller}.
+ * @author Jeroen de Jong
+ */
+@Value
+public class ControllerSetPublisher<C extends Controller>
+    implements Publisher<Controller.SetSupplier<C>> {
+
+  /**
+   * Duration between polls.
+   */
+  private final Duration interval;
+  /**
+   * Adapter used to transform jamepad state.
+   */
+  private final Function<ControllerIndex, C> adapter;
+  /**
+   * Jamepad backend for managing controllers
+   */
+  private final ControllerManager manager;
+
+  /**
+   * Constructs ControllerSetPublisher and initializes native extensions.
+   *
+   * @param interval Duration between polls.
+   * @param adapter Adapter used to transform jamepad state.
+   * @param amount Amount of controllers to listen for.
+   */
+  public ControllerSetPublisher(
+      final Duration interval,
+      final Function<ControllerIndex, C> adapter,
+      final int amount
+  ) {
+    this.manager = new ControllerManager(amount);
+    this.manager.initSDLGamepad();
+    this.interval = interval;
+    this.adapter = adapter;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void subscribe(final Subscriber<? super Controller.SetSupplier<C>> subscriber) {
+    Flux.interval(interval)
+        .map(tick ->
+            // Loop all controllers
+            IntStream.range(0, manager.getNumControllers())
+                // grab the states
+                .mapToObj(manager::getControllerIndex)
+                // ignore any disconnected controller
+                .filter(ControllerIndex::isConnected)
+                // map to custom state and collect as a set.
+                .map(adapter)
+                .collect(Collectors.toSet()))
+        .map(Frame::new)
+        .subscribe(subscriber);
+  }
+
+  /**
+   * The Class Frame.
+   *
+   * @author Jeroen de Jong
+   */
+  @Value
+  private class Frame implements Controller.SetSupplier<C> {
+    /**
+     * The {@link Set} of {@link Controller controllers} captured in this frame.
+     */
+    private Set<C> controllerSet;
+  }
+}

--- a/src/main/java/io/leonis/zosma/ipc/peripheral/ControllerSetPublisher.java
+++ b/src/main/java/io/leonis/zosma/ipc/peripheral/ControllerSetPublisher.java
@@ -60,28 +60,14 @@ public class ControllerSetPublisher<C extends Controller>
     Flux.interval(interval)
         .map(tick ->
             // Loop all controllers
-            IntStream.range(0, manager.getNumControllers())
-                // grab the states
-                .mapToObj(manager::getControllerIndex)
-                // ignore any disconnected controller
-                .filter(ControllerIndex::isConnected)
-                // map to custom state and collect as a set.
-                .map(adapter)
-                .collect(Collectors.toSet()))
-        .map(Frame::new)
+            () -> IntStream.range(0, manager.getNumControllers())
+                    // grab the states
+                    .mapToObj(manager::getControllerIndex)
+                    // ignore any disconnected controller
+                    .filter(ControllerIndex::isConnected)
+                    // map to custom state and collect as a set.
+                    .map(adapter)
+                    .collect(Collectors.toSet()))
         .subscribe(subscriber);
-  }
-
-  /**
-   * The Class Frame.
-   *
-   * @author Jeroen de Jong
-   */
-  @Value
-  private class Frame implements Controller.SetSupplier<C> {
-    /**
-     * The {@link Set} of {@link Controller controllers} captured in this frame.
-     */
-    private Set<C> controllerSet;
   }
 }

--- a/src/main/java/io/leonis/zosma/ipc/peripheral/ControllerSetPublisher.java
+++ b/src/main/java/io/leonis/zosma/ipc/peripheral/ControllerSetPublisher.java
@@ -58,7 +58,7 @@ public class ControllerSetPublisher<C extends Controller>
   @Override
   public void subscribe(final Subscriber<? super Controller.SetSupplier<C>> subscriber) {
     Flux.interval(interval)
-        .map(tick ->
+        .<Controller.SetSupplier<C>>map(tick ->
             // Loop all controllers
             () -> IntStream.range(0, manager.getNumControllers())
                     // grab the states


### PR DESCRIPTION
This allows for dynamic rebinding of the controllers to the players.  

An example for subra that'll increase the id of the assigned robot by 1 every 500ms would be:
```java
Publisher<Controller.MapSupplier> mappingPublisher = Flux.interval(Duration.ofMillis(500))
  .map(tick -> () -> ImmutableMap.of(
    new PlayerIdentity(tick.intValue(), TeamColor.BLUE),
    ImmutableSet.of(new ControllerIdentity(1)))

new Zosma(
  new ControllerPublisher<>(2, Duration.ofMillis(100), new XboxJamepadAdapter(), mappingPublisher),
  new ControllerDeducer<>(new ControllerHandler<>(), AveragePlayerCommand::new),
  System.out::println
).run();
```
Note that the the flux returns a lambda, so it acts as an `Controller.MapSupplier`.